### PR TITLE
Seção de sugestão/mudança das regras

### DIFF
--- a/_posts/15-04-01-Collaborating.md
+++ b/_posts/15-04-01-Collaborating.md
@@ -1,0 +1,21 @@
+---
+title: Sugestões
+anchor: sugestoes
+---
+
+Nossas regras são [um repositório Git aberto][repo] que você pode [forkar][],
+modificar e enviar as mudanças pra gente.
+
+Todas as regras podem ser mudadas, conquanto que:
+
+1. O autor da [Pull Request][1] seja um membro, não banido, da comunidade.
+1. A [PR][1] fique aberta 7 dias após o início da votação.
+1. A [PR][1] não mude após o início da votação.
+1. Uma [PR][1] **pode sofrer** merge se possuir mais de 2/3 de votos a favor.
+1. Um voto só é considerado se o membro não estiver banido.
+
+As regras ativas são sempre as presentes na `HEAD` do branch `gh-pages`.
+
+[1]: https://help.github.com/articles/creating-a-pull-request/
+[forkar]: https://help.github.com/articles/creating-a-pull-request/
+[repo]: https://github.com/php-brasil/Documentos


### PR DESCRIPTION
Formaliza o processo de mudança das regras além de deixar ele explícito
na própria página das regras.
Um processo formal torna ele mais aberto e democrático, porém existe uma
cláusula formal que não garante que toda _nova regra votada_ seja
obrigatoriamente mergeada.

Acredito que o uso dessa cláusula mereça ser esclarecido com relação ao
intuito de defender o objetivo "de gerar discussão construtiva e
conhecimento" do grupo. Essa defesa deve ser interpretada pelos moderes,
nada mais justo do que isso quando são eles que autorizam um-a-um os
membros e moderam o conteúdo.

RFC @php-brasil/contributors 
