### PR TITLE
Permitir ban de trolls

### DIFF
--- a/_posts/14-08-01-2-2-Rules-About-Post-Content.md
+++ b/_posts/14-08-01-2-2-Rules-About-Post-Content.md
@@ -10,3 +10,4 @@ Antes de postar qualquer coisa no grupo, leia as regras abaixo.
 2. [x] Postagem de arquivos **apenas** através de links.
 3. [x] Postagem de códigos **apenas** através de links.
 4. [x] Caixa alta é permitida apenas para dar ênfase em algum termo. Postagens totalmente em caixa alta **são proibidas**.
+5. [x] As participações devem ser construtivas. Cada autor é responsável por se comunicar com os demais a fim de estabelecer diálogo. Como desenvolvedores, aceitamos ironia e outras figuras de linguagem (e porque não trolagens) mas desde que elas não se tornem o assunto.


### PR DESCRIPTION
Com o objetivo do grupo sendo a constante discussão, proponho um adendo
às regras que permite com que os administradores concordem em banir um
determinado participante por não colaborar de fato com o grupo.

Discussões são resultado da participação de várias pessoas, mas quando
uma não cosegue (nem se esforça) pra se comunicar com as demais, a
discussão toda tende a perder o propósito. É utópico imaginar que iremos
evitar isso, mas é irresponsável manter uma pessoa no grupo que só
provoca isso em todas as threads que participa.
## Resultados

| # | Membro | Voto |
| --- | --- | --- |
| 1 | @augustohp (autor) | +1 |
| 2 | @netojoaobatista | +1 |
| 3 | @GabrielJMJ | +1 |
| 4 | @jackmakiyama | +1 |
| 5 | @icaromh | +1 |
| 6 | @natanaellopes | +1 |
| 7 | @brunosserrao | +1 |
| 8 | @edsonlimadev | +1 |
| 9 | @hussani | +1 |
| 10 | @vinicius-ianni | +1 |
| 11 | @malukenho | -1 |
| 12 | @VitorArjol | +1 |
| 13 | @leandro-lugaresi | +1 |
| 14 | @davidwillianx | +1 |
| 15 | @LuizMaster | +1 |
| 16 | @lcobucci | +1 |
| 17 | @danjesus | +1 |
| 18 | @iBrunoSan | +1 |
| 19 | @hugoseabra | -1 |
| 20 | @guiajlopes | -1 |
| 21 | @kinncj | -1 |
| 22 | @brunogasparetto | \+ 1 |
| 23 | @LucasBurg | +1 |
| 24 | @brenodouglas | -1 |
## Conclusão

| Critério | Valor |
| --- | --- |
| Total de votos | 24 |
| Votos necessários para aprovação (2/3) | 16 |
| Votos a favor | 19 |
| Votos contra | 5 |

Resultado: Alteração aceita.
