### PR TITLE
Redução de redundâncias, remoção de task lists e listas aninhadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Documentos e regras da comunidade
 
-Para leitura das regras, por favor, acesse o link [Regras do grupo PHP Brasil](http://phpbr.org/Documentos/)
+Para leitura das regras, por favor, acesse o link [Regras do grupo PHP Brasil](http://php-brasil.github.io/Documentos/)

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -5,7 +5,7 @@
     {% if firstPost %}
         {% assign firstPost = false %}
     {% endif %}
-        <div id="{{ post.anchor }}" style="display: block; position: relative; top: -100px; visibility: hidden;"></div>
+        <div id="{{ post.anchor }}" class="anchor"></div>
         <section>
 
     {% if post.isChild != true %}

--- a/_layouts/php-brasil.html
+++ b/_layouts/php-brasil.html
@@ -48,15 +48,17 @@
                             {% endif %}
                         {% endfor %}
                     </ul>
-                    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
-                        <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/80x15.png" />
-                    </a>
                 </div>
                 <div class="span9" id="content">
                     {% include content.html %}
                     <section>
                         <footer id="page-footer">
-                            <p><a href="http://php.net/docs.php" target="_blank">Documentação do PHP</a></a>.</p>
+                            <p><a href="http://php.net/docs.php" target="_blank">Documentação do PHP</a>.</p>
+                            <p>
+                                <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+                                    <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/80x15.png" />
+                                </a>
+                            </p>
                         </footer>
                     </section>
                 </div>

--- a/_layouts/php-brasil.html
+++ b/_layouts/php-brasil.html
@@ -20,9 +20,6 @@
         <link href="theme/styles/default/bootstrap.css" rel="stylesheet" />
         <link href="theme/styles/default/bootstrap_responsive.css" rel="stylesheet" />
         <link href="theme/styles/default/php-brasil.css" rel="stylesheet" />
-        <style>
-        section {margin-top: 30px;}
-        </style>
     </head>
     <body data-spy="scroll" data-target="#navbar" data-offset="1">
         <div class="navbar navbar navbar-fixed-top">
@@ -42,7 +39,7 @@
         </div>
         <div class="container">
             <div class="row">
-                <div class="span3 bs-docs-sidebar" id="navbar" style="margin-top: 133px;">
+                <div class="span3 bs-docs-sidebar" id="navbar">
                     {% assign lastIsChild = false %}
                     <ul class="nav nav-pills nav-stacked bs-docs-sidenav affix">
                         {% for post in site.posts reversed %}
@@ -52,19 +49,15 @@
                         {% endfor %}
                     </ul>
                     <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
-                        <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" />
+                        <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/80x15.png" />
                     </a>
                 </div>
-                <div class="span9" style="margin-top: 100px;">
+                <div class="span9" id="content">
                     {% include content.html %}
                     <section>
-                        <div>
-                            <footer>
-                                <div align="left" style="margin-top:330px; margin-bottom:50px;">
-                                    <p><a href="http://php.net/docs.php" target="_blank">Documentação do PHP</a></a>.</p>
-                                </div>
-                            </footer>
-                        </div>
+                        <footer id="page-footer">
+                            <p><a href="http://php.net/docs.php" target="_blank">Documentação do PHP</a></a>.</p>
+                        </footer>
                     </section>
                 </div>
             </div>

--- a/_posts/14-08-01-1-1-Welcome.md
+++ b/_posts/14-08-01-1-1-Welcome.md
@@ -4,6 +4,13 @@ isChild: true
 anchor: bem-vindo
 ---
 
-Seja bem vindo ao PHP Brasil! Antes de postar qualquer coisa, atenção:
+Seja bem vindo ao PHP Brasil!
 
-Não faremos seu trabalho. Não faremos seu dever de casa. Nós não resolveremos problemas relacionados com o seu trabalho ou seu dever de casa. Permitimos e incentivamos a discussão. Permitimos e incentivamos os diversos pontos de vista que cada um pode ter. Nós permitimos apenas questões que causem a discussão entre os membros do grupo, promovendo assim o crescimento de toda a comunidade PHP Brasil.
+**Antes de postar qualquer coisa, atenção:**
+
+* Não faremos seu trabalho.
+* Não faremos seu dever de casa.
+* Nós não resolveremos problemas relacionados com o seu trabalho ou seu dever de casa.
+* Permitimos e incentivamos a discussão.
+* Permitimos e incentivamos os diversos pontos de vista que cada um pode ter.
+* Nós permitimos apenas questões que causem a discussão entre os membros do grupo, promovendo assim o crescimento de toda a comunidade PHP Brasil.

--- a/_posts/14-08-01-2-0-Rules.md
+++ b/_posts/14-08-01-2-0-Rules.md
@@ -3,6 +3,10 @@ title: Regras
 anchor: regras
 ---
 
-Essas são as regras do grupo PHP Brasil. Ao entrar no grupo, você deve seguir todas as regras abaixo, ou deixar o grupo. Você é livre para entrar e sair a qualquer momento, mas se for banido, você jamais será permitido voltar ao grupo.
+Essas são as regras do grupo PHP Brasil.
 
-**Leia-as com atenção, pois ao permanecer no grupo, você estará concordando com cada uma delas.**
+Ao entrar no grupo você deve seguir todas as regras desse documento.
+
+Você é livre para entrar e sair do grupo a qualquer momento, mas ao ser banido você jamais voltará ao grupo.
+
+**Leia as regras com atenção, pois ao permanecer no grupo você estará concordando com cada uma delas.**

--- a/_posts/14-08-01-2-1-Rules-Violations.md
+++ b/_posts/14-08-01-2-1-Rules-Violations.md
@@ -8,7 +8,7 @@ Os administradores e membros da comunidade devem tratar todos os membros da form
 
 Ao não seguir as regras o membro estará desrespeitando toda a comunidade.
 
-**A violação recorrente às regras não será tolerado de forma alguma.**
+**A violação recorrente às regras não será tolerada de forma alguma.**
 
 Caso você tenha acabado de chegar no grupo e algum administrador lhe enviou o link para esse documento, então significa que você violou alguma regra.
 

--- a/_posts/14-08-01-2-1-Rules-Violations.md
+++ b/_posts/14-08-01-2-1-Rules-Violations.md
@@ -4,7 +4,11 @@ isChild: true
 anchor: violacao-as-regras
 ---
 
-Os administradores e membros da comunidade procurarão, sempre, tratar todos os membros da forma mais educada e gentil possível. Porém, o respeito deve ser sempre bilateral. Ao não seguir as regras, o membro estará desrespeitando toda a comunidade. Todos os membros são livres para sair do grupo, caso não concorde com as regras. A violação recorrente às regras não será tolerado de forma alguma.
+Os administradores e membros da comunidade devem tratar todos os membros da forma mais educada e gentil possível. Esse respeito deve ser sempre bilateral.
+
+Ao não seguir as regras o membro estará desrespeitando toda a comunidade.
+
+**A violação recorrente às regras não será tolerado de forma alguma.**
 
 Caso você tenha acabado de chegar no grupo e algum administrador lhe enviou o link para esse documento, então significa que você violou alguma regra.
 

--- a/_posts/14-08-01-2-2-Rules-About-Post-Content.md
+++ b/_posts/14-08-01-2-2-Rules-About-Post-Content.md
@@ -6,8 +6,8 @@ anchor: regras-relacionadas-com-conteudo-da-postagem
 
 Antes de postar qualquer coisa no grupo, leia as regras abaixo.
 
-1. [x] Português é o único idioma aceito no grupo.
-2. [x] Postagem de arquivos **apenas** através de links.
-3. [x] Postagem de códigos **apenas** através de links.
-4. [x] Caixa alta é permitida apenas para dar ênfase em algum termo. Postagens totalmente em caixa alta **são proibidas**.
-5. [x] As participações devem ser construtivas. Cada autor é responsável por se comunicar com os demais a fim de estabelecer diálogo. Como desenvolvedores, aceitamos ironia e outras figuras de linguagem (e porque não trolagens) mas desde que elas não se tornem o assunto.
+1. Português é o único idioma aceito no grupo.
+2. Postagem de arquivos **apenas** através de links.
+3. Postagem de códigos **apenas** através de links ([Gist](https://gist.github.com/) é uma boa opção).
+4. Caixa alta é permitida apenas para dar ênfase em algum termo. Postagens totalmente em caixa alta **são proibidas**.
+5. As participações devem ser construtivas. Cada autor é responsável por se comunicar com os demais a fim de estabelecer diálogo. Como desenvolvedores, aceitamos ironia e outras figuras de linguagem (e até trolagens), mas desde que elas não se tornem o assunto.

--- a/_posts/14-08-01-2-3-Rules-About-Code.md
+++ b/_posts/14-08-01-2-3-Rules-About-Code.md
@@ -6,18 +6,24 @@ anchor: regras-relacionadas-com-codigo
 
 Antes de postar qualquer coisa no grupo, que seja referente ao código que você escreveu ou precisa escrever, leia as regras abaixo.
 
-1. [ ] Você tem uma mensagem de erro, mas não sabe o que é nem como resolver.
-    * O grupo **não é** o lugar para você pedir ajuda com mensagens de erro. Se você fizer uma pesquisa rápida com a mensagem de erro, verá outros usuários já tiveram problemas com essa mesma mensagem e a solução está disponível na íntegra, em diversos canais.
-    * **Se você postar esse tipo de conteúdo, será convidado a apagá-lo e, se não fizê-lo, será punido.**
-2. [ ] Você precisa fazer alguma coisa, mas seu algorítimo não funciona como esperado.
-    * O grupo **não é** o lugar para você pedir ajuda com seu algorítimo. Nós não faremos seu trabalho ou seu dever de casa.
-    * **Se você postar esse tipo de conteúdo, será convidado a apagá-lo e, se não fizê-lo, será punido.**
-3. [x] Você precisa fazer alguma coisa, mas não tem ideia de como fazê-lo.
-    * O grupo **não é** o lugar para você pedir ajuda com código que você não sabe como implementar. Existem, porém, questões sobre boas práticas ou questões conceituais, sobre padrões, escalabilidade, manutenção, que são bem vindas no grupo. **Se você sabe como implementar**, mas quer opiniões sobre melhores práticas, então sua questão promoverá uma discussão e sempre incentivaremos uma boa discussão.
-    * **Se você postar uma dúvida com código que não sabe implementar, será convidado a apagá-lo e, se não fizê-lo, será punido.**
-4. [x] Você já escreveu seu código, mas quer que a comunidade analise-o com o objetivo de ajudá-lo a melhorá-lo.
-    * Esse tipo de questão, normalmente, produz excelentes discussões.  Abrir seu código para análise, porém, produzirá críticas ao código. Esteja ciente que sempre respeitaremos o autor do código. O código em si, porém, não merece respeito. Ao postar seu código, esteja preparado para separar o respeito que temos por você, do respeito que não teremos pelo código. Se você conseguir fazer essa separação, você poderá colher muitos bons resultados a partir da análise crítica do seu código.
-5. [x] Você já escreveu seu código, mas quer sugestões de boas práticas.
-    * A primeira boa prática, você já seguiu ao buscar conhecimento sobre boas práticas. Apenas lembre-se que respeitamos apenas o autor, nunca o código. Ao postar código em busca de sugestões, muito possivelmente seu código sofrerá críticas diversas. Ao postar seu código, esteja preparado para separar o respeito que temos por você, do respeito que não teremos pelo código. Se você conseguir fazer essa separação, você poderá colher muitos bons resultados a partir da análise crítica do seu código.
-6. [x] Você já escreveu seu código, mas quer sugestões de escalabilidade.
-    * O grupo é composto por profissionais PHP que trabalham em sistemas diversos, muitas vezes sistemas de grande porte. Estamos sempre dispostos a compartilhar conhecimento sobre escalabilidade e manutenção de software. Esse tipo de questão normalmente produz discussões interessantes, com sugestões de ferramentas e técnicas que permitirão e melhorarão a escalabilidade da aplicação.
+1. **Você tem uma mensagem de erro, mas não sabe o que é e nem como resolver?**
+
+    O grupo **não é** o lugar para você pedir ajuda com mensagens de erro. Se você fizer uma pesquisa com a mensagem de erro verá outros usuários que já tiveram problemas com essa mesma mensagem e a solução está disponível na íntegra em diversos canais.
+
+2. **Você precisa fazer alguma coisa, mas seu algorítimo não funciona como esperado?**
+
+    O grupo **não é** o lugar para você pedir ajuda com seu algorítimo. Nós não faremos seu trabalho ou seu dever de casa.
+
+3. **Você precisa fazer alguma coisa, mas não tem ideia de como fazê-lo?**
+
+    O grupo **não é** o lugar para você pedir ajuda com código que você não sabe como implementar. Entretanto questões conceituais são bem vindas por fomentarem uma boa discussão.
+
+4. **Você já escreveu seu código, mas quer que a comunidade o analise com o objetivo de ajudar a melhorá-lo, seja com boas práticas, escalabilidade ou manutenção de software?**.
+
+    O grupo é composto por profissionais PHP que trabalham em sistemas diversos, muitas vezes sistemas de grande porte. Estamos sempre dispostos a compartilhar conhecimento sobre boas práticas, escalabilidade e manutenção de software.
+    
+    Esse tipo de questão normalmente produz discussões interessantes, com sugestões de ferramentas e técnicas que permitirão e melhorarão a escalabilidade da aplicação.
+
+**Antes de postar o seu código lembre-se:**
+
+Abrir seu código para análise produzirá críticas ao código. Esteja ciente que sempre respeitaremos o autor do código, mas o código em si não merece respeito. Ao postar seu código esteja preparado para separar o respeito que temos por você, do respeito que não teremos pelo código. Se conseguir fazer essa separação você poderá colher muitos bons resultados a partir da análise crítica do seu código.

--- a/_posts/14-08-01-2-3-Rules-About-Code.md
+++ b/_posts/14-08-01-2-3-Rules-About-Code.md
@@ -10,13 +10,19 @@ Antes de postar qualquer coisa no grupo, que seja referente ao código que você
 
     O grupo **não é** o lugar para você pedir ajuda com mensagens de erro. Se você fizer uma pesquisa com a mensagem de erro verá outros usuários que já tiveram problemas com essa mesma mensagem e a solução está disponível na íntegra em diversos canais.
 
+    Se você postar esse tipo de conteúdo, será convidado a apagá-lo e, se não fizê-lo, será punido.
+
 2. **Você precisa fazer alguma coisa, mas seu algorítimo não funciona como esperado?**
 
     O grupo **não é** o lugar para você pedir ajuda com seu algorítimo. Nós não faremos seu trabalho ou seu dever de casa.
 
+    Se você postar esse tipo de conteúdo, será convidado a apagá-lo e, se não fizê-lo, será punido.
+
 3. **Você precisa fazer alguma coisa, mas não tem ideia de como fazê-lo?**
 
     O grupo **não é** o lugar para você pedir ajuda com código que você não sabe como implementar. Entretanto questões conceituais são bem vindas por fomentarem uma boa discussão.
+
+    Se você postar uma dúvida com código que não sabe implementar, será convidado a apagá-lo e, se não fizê-lo, será punido.
 
 4. **Você já escreveu seu código, mas quer que a comunidade o analise com o objetivo de ajudar a melhorá-lo, seja com boas práticas, escalabilidade ou manutenção de software?**.
 

--- a/_posts/14-08-01-2-4-Rules-About-Advertising.md
+++ b/_posts/14-08-01-2-4-Rules-About-Advertising.md
@@ -6,15 +6,15 @@ anchor: regras-relacionadas-com-publicidade-e-divulgacoes
 
 Antes de postar qualquer coisa no grupo, que seja referente à publicidade e divulgações, leia as regras abaixo.
 
-1. [ ] Não permitimos divulgações de empresas;
-2. [ ] Não permitimos divulgações de páginas do Facebook, Google+ ou qualquer outra;
-3. [ ] Não permitimos divulgações de páginas pessoais, portfolios, etc;
-4. [ ] Não permitimos divulgações de vagas de trabalho fixo ou temporário, nem ofertas para freelancers;
-5. [x] Permitimos a divulgação de cursos e eventos relacionados com PHP, gratuitos ou pagos, **desde que não possuam caráter autopromocional** e sigam os seguintes critérios:
-    1. Cursos e eventos gratuitos - permitidos tanto presenciais quanto online.
-    2. Cursos e eventos pagos - apenas **mediante aprovação expressa dos administradores**, desde que haja uma vantagem para o grupo. Ex: Desconto, cortesias, etc.
-6. [x] Permitimos a divulgação de open source relacionado com PHP, como bibliotecas, frameworks, etc.
-7. [x] Permitimos a divulgação de pesquisas no grupo, acadêmicas ou não, desde que sigam os seguintes critérios: 
+1. **Não** permitimos divulgações de empresas.
+2. **Não** permitimos divulgações de páginas do Facebook, Google+ ou qualquer outra.
+3. **Não** permitimos divulgações de páginas pessoais, portfolios, etc.
+4. **Não** permitimos divulgações de vagas de trabalho nem ofertas para freelancers.
+5. Permitimos a divulgação de cursos e eventos relacionados com PHP, gratuitos ou pagos, **desde que não possuam caráter autopromocional** e sigam os seguintes critérios:
+    1. Cursos e eventos gratuitos são permitidos tanto presenciais quanto online.
+    2. Cursos e eventos pagos são permitidos **mediante aprovação expressa dos administradores** e desde que haja uma vantagem para o grupo. Ex: Desconto, cortesias, etc.
+6. Permitimos a divulgação de open source relacionado com PHP, como bibliotecas, frameworks, etc.
+7. Permitimos a divulgação de pesquisas no grupo, acadêmicas ou não, desde que sigam os seguintes critérios: 
     1. Esteja dentro do escopo do grupo.
     2. **Que o resultado da pesquisa seja público desde o início**, ou seja, o autor/pesquisador/responsável pela pesquisa se compromete a manter os resultados parciais e totais abertos para consulta pública.
 

--- a/theme/images/php-brasil.svg
+++ b/theme/images/php-brasil.svg
@@ -98,7 +98,7 @@
            x="-458.57999"
            y="-264.72797"
            id="tspan4490"
-           style="font-size:250px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:#ededed;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans Bold">php Brasil</tspan></text>
+           style="font-size:250px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:#ededed;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans Bold">PHP Brasil</tspan></text>
     </g>
   </g>
 </svg>

--- a/theme/styles/default/php-brasil.css
+++ b/theme/styles/default/php-brasil.css
@@ -5,3 +5,8 @@ h2 {margin: 30px 0 10px;}
 .row {background: #ffffff;}
 .nav-pills > .active > a, .nav-pills > .active > a:hover, .nav-pills > .active > a:focus {background: #171717;}
 .span9 {width: 830px;}
+.anchor {display: block; position: relative; top: -100px; visibility: hidden;}
+section {margin-top: 30px;}
+#navbar {margin-top: 133px;}
+#content {margin-top: 100px;}
+#page-footer {margin-top:330px; margin-bottom:50px; padding-top: 10px; border-top: 1px solid #eeeeee;}


### PR DESCRIPTION
As regras possuíam muitas redundâncias (o mesmo aviso sobre crítica ao código em vários itens) e por isso o texto estava inchado demais.

As task lists estavam com problema na renderização (ficavam somente com o [x]) e por isso poluíam demais o visual e as listas aninhadas deixavam o visual mais confuso.

As regras 4, 5 e 6, da seção sobre Código, tratavam quase do mesmo assunto, por isso as agrupei em um único item.

Várias pequenas alterações no texto com objetivo de facilitar a leitura.

Para uma comparação mais visual: https://brunogasparetto.github.io/Documentos/